### PR TITLE
Update 02.md: fix small typo

### DIFF
--- a/manuscript/02.md
+++ b/manuscript/02.md
@@ -195,7 +195,7 @@ In addition, Nx allows the dependencies between libraries to be visualized:
 
 ![Nx visualizes the dependencies between libraries](images/graph.png)
 
-If you want to see all of this in action, feel free to have a look at the Nx version of the example used here. Your find the [Source Code at GitHub](https://github.com/manfredsteyer/demo-nx-standalone).
+If you want to see all of this in action, feel free to have a look at the Nx version of the example used here. You'll find the [Source Code at GitHub](https://github.com/manfredsteyer/demo-nx-standalone).
 
 Besides enforcing module boundaries, Nx also comes with several additional important features: It allows for an incremental CI/CD that only rebuilds and retests parts of the monorepo that have been actually affected by a code change. Also, together with the Nx Cloud it allows to automatically parallelize the whole CI/CD process. Also, it comes with integrations into several useful tools like Storybook, Cypress, or Playwright.
 


### PR DESCRIPTION
This commit fixes another small typo, replacing `your` with `you'll` to match the context.